### PR TITLE
emonacho/wrappers modified libft

### DIFF
--- a/lib/libft/Makefile
+++ b/lib/libft/Makefile
@@ -42,8 +42,11 @@ ft_strtrim.c \
 ft_substr.c \
 ft_tolower.c \
 ft_toupper.c \
+w_calloc.c \
+w_free.c \
 w_kill.c \
-wft_calloc.c
+w_malloc.c
+
 
 OBJS	= $(SRCS:.c=.o)
 

--- a/lib/libft/ft_calloc.c
+++ b/lib/libft/ft_calloc.c
@@ -6,7 +6,7 @@
 /*   By: emonacho <emonacho@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/19 11:25:21 by emonacho          #+#    #+#             */
-/*   Updated: 2025/04/04 17:41:04 by emonacho         ###   ########.fr       */
+/*   Updated: 2025/04/04 20:49:07 by emonacho         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,13 +17,13 @@ void	*ft_calloc(size_t nmemb, size_t size)
 {
 	unsigned char	*new_str;
 	size_t			total_size;
-	size_t			i;
 
-	if (nmemb == 0 || size == 0)
-		return (NULL);
-	if (nmemb > SIZE_MAX / size)
+	if (nmemb > SIZE_MAX / size || nmemb == 0 || size == 0)
 	{
-		errno = EOVERFLOW;
+		if (nmemb == 0 || size == 0)
+			errno = EINVAL;
+		else
+			errno = EOVERFLOW;
 		return (NULL);
 	}
 	total_size = nmemb * size;
@@ -33,11 +33,11 @@ void	*ft_calloc(size_t nmemb, size_t size)
 		errno = ENOMEM;
 		return (NULL);
 	}
-	i = 0;
-	while (i < total_size)
+	while (total_size > 0)
 	{
-		new_str[i] = 0;
-		i++;
+		new_str[total_size] = 0;
+		total_size--;
 	}
+	new_str[total_size] = 0;
 	return (new_str);
 }

--- a/lib/libft/ft_strjoin.c
+++ b/lib/libft/ft_strjoin.c
@@ -3,16 +3,16 @@
 /*                                                        :::      ::::::::   */
 /*   ft_strjoin.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: timmi <timmi@student.42.fr>                +#+  +:+       +#+        */
+/*   By: emonacho <emonacho@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/19 11:52:28 by emonacho          #+#    #+#             */
-/*   Updated: 2025/04/03 16:31:20 by timmi            ###   ########.fr       */
+/*   Updated: 2025/04/04 20:31:00 by emonacho         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-char *ft_strjoin(const char *s1, const char *s2)
+char	*ft_strjoin(const char *s1, const char *s2)
 {
 	char	*new_str;
 	int		i;

--- a/lib/libft/libft.h
+++ b/lib/libft/libft.h
@@ -6,7 +6,7 @@
 /*   By: emonacho <emonacho@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/10 11:08:29 by emonacho          #+#    #+#             */
-/*   Updated: 2025/04/04 17:41:02 by emonacho         ###   ########.fr       */
+/*   Updated: 2025/04/04 20:49:04 by emonacho         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -79,7 +79,9 @@ int		ft_atoi_safe(const char *str, int *error);
 void	ft_puterror(char *error_location, char *error_msg);
 
 // wrappers
-void	*wft_calloc(size_t nmemb, size_t size);
+void	w_free(void **ptr);
 void	w_kill(pid_t pid, int signal);
+void	w_malloc(void **ptr, size_t size);
+void	*w_calloc(size_t nmemb, size_t size);
 
 #endif

--- a/lib/libft/w_calloc.c
+++ b/lib/libft/w_calloc.c
@@ -1,19 +1,27 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   w_kill.c                                           :+:      :+:    :+:   */
+/*   w_calloc.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: emonacho <emonacho@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2025/04/03 17:17:53 by emonacho          #+#    #+#             */
-/*   Updated: 2025/04/04 19:42:58 by emonacho         ###   ########.fr       */
+/*   Created: 2025/04/04 14:42:42 by emonacho          #+#    #+#             */
+/*   Updated: 2025/04/04 20:49:06 by emonacho         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-void	w_kill(pid_t pid, int signal)
+// Call with: `[PTR] = w_calloc([NMEMB], [SIZE]);`
+void	*w_calloc(size_t nmemb, size_t size)
 {
-	if (kill(pid, signal) < 0)
-		ft_puterror("w_kill failed", strerror(errno));
+	char	*new_str;
+
+	new_str = ft_calloc(nmemb, size);
+	if (new_str == NULL)
+	{
+		ft_puterror("w_calloc failed", strerror(errno));
+		return (NULL);
+	}
+	return (new_str);
 }

--- a/lib/libft/w_free.c
+++ b/lib/libft/w_free.c
@@ -1,26 +1,25 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   wft_calloc.c                                       :+:      :+:    :+:   */
+/*   w_free.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: emonacho <emonacho@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2025/04/04 14:42:42 by emonacho          #+#    #+#             */
-/*   Updated: 2025/04/04 17:41:07 by emonacho         ###   ########.fr       */
+/*   Created: 2025/04/04 19:21:57 by emonacho          #+#    #+#             */
+/*   Updated: 2025/04/04 20:49:08 by emonacho         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-void	*wft_calloc(size_t nmemb, size_t size)
+// Call with: `w_free((void **)&char_str)`
+void	w_free(void **ptr)
 {
-	char	*new_str;
-
-	new_str = ft_calloc(nmemb, size);
-	if (new_str == NULL)
+	if (ptr == NULL || *ptr == NULL)
+		ft_puterror("w_free warning", "Trying to free a NULL pointer.");
+	else if (*ptr != NULL)
 	{
-		ft_puterror("wft_calloc failed", strerror(errno));
-		return (NULL);
+		free(*ptr);
+		*ptr = NULL;
 	}
-	return (new_str);
 }

--- a/lib/libft/w_malloc.c
+++ b/lib/libft/w_malloc.c
@@ -1,19 +1,31 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   w_kill.c                                           :+:      :+:    :+:   */
+/*   w_malloc.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: emonacho <emonacho@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2025/04/03 17:17:53 by emonacho          #+#    #+#             */
-/*   Updated: 2025/04/04 19:42:58 by emonacho         ###   ########.fr       */
+/*   Created: 2025/04/04 19:27:26 by emonacho          #+#    #+#             */
+/*   Updated: 2025/04/04 20:49:08 by emonacho         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-void	w_kill(pid_t pid, int signal)
+// Call with: `w_malloc((void **)&[PTR], [SIZE]);`
+void	w_malloc(void **ptr, size_t size)
 {
-	if (kill(pid, signal) < 0)
-		ft_puterror("w_kill failed", strerror(errno));
+	if (size <= 0)
+	{
+		*ptr = NULL;
+		ft_puterror("w_malloc failed",
+			"`size` must be a non-zero positive value.");
+		return ;
+	}
+	*ptr = malloc(size);
+	if (*ptr == NULL)
+	{
+		errno = ENOMEM;
+		ft_puterror("w_malloc failed", strerror(errno));
+	}
 }


### PR DESCRIPTION
## What has been done?
**Ajout des `wrappers`:**
- `w_free`
- `w_malloc`
- Insertion de ces deux fonctions dans le `Makefile` et le `.h`
**Corrections `wft_calloc`:**
- Renomme en `w_calloc` (c'est plus joli et lisible)
- Refactorisation d'une partie de la fonction
**+ une petite correction de norminette sur `ft_strjoin`**

## Usage
-`w_calloc`  doit etre appele ainsi: `[PTR] = w_calloc([NMEMB], [SIZE]);`
_([NMEMB] correspond a un `sizeof(char)`, `sizeof(int)` ou autre...)_
-`w_free` doit etre appele ainsi: `w_free((void **)&[PTR])`
-`w_malloc` doit etre appele ainsi: `w_malloc((void **)&[PTR], [SIZE]);`